### PR TITLE
Incorporating fixes from Vini's example

### DIFF
--- a/CBM_vol2biomass.R
+++ b/CBM_vol2biomass.R
@@ -287,7 +287,7 @@ Init <- function(sim) {
                                           sim$table4$ecozone %in% eco, ])
   }
 
-  abreviation <- c("PE", "QC", "ON", "MB", "SK", "YK", "NU")
+  abreviation <- c("PE", "QC", "ON", "MB", "SK", "YK", "NU", "NS")
   ## DANGER HARD CODED: if NFIS changes table 5, this will no longer be valid
   # juris_id: there are only 5/13 possible
   # these are the provinces available: AB BC NB NF NT
@@ -299,8 +299,9 @@ Init <- function(sim) {
   # "SK" - AB
   # "YK" - NT
   # "NU" - NT
+  # "NS" - NB
   if (any(thisAdmin$abreviation %in% abreviation)) {
-    t5abreviation <- c("NB", "NL", "NL", "AB", "AB", "NT", "NT")
+    t5abreviation <- c("NB", "NL", "NL", "AB", "AB", "NT", "NT", "NB")
     abreviationReplace <- data.table(abreviation, t5abreviation)
     # replace the abbreviations and select
     thisAdmin5 <- merge(abreviationReplace, thisAdmin)


### PR DESCRIPTION
How we deal with tables3-7 is more robust to other provinces/territories. ON and QC now use NL instead of NB for table5 (NB only had 1 ecozone, so any study area in ON or QC would fail. It also now replaces the ecozones in thisAdmin to the corresponding ecozones in tables3-7 when needed. 
NS was entirely missing from table5, with no replacement like other provinces/territories with this issue. This has been changed so that NS uses NB (as I assume they are both fully in the Atlantic Maritime ecozone). 
Also added a fix to the birch workaround. Previously, vol2biomass would fail if the study area did not have that growth curve. It now only runs the birch workaround code if the gcids are present. 
Added a dated comment on line 410 `gcidsLevels <- levels(sim$level3DT$gcids)` This caused errors in Vini's example and I instead used `gcidsLevels <- unique(sim$level3DT$gcids)`. I did not change this in this version but left it in a comment. I think that was due to the fact that Vini's example only had 1 unique value. 
Runs with our current spadesCBM SK example. 