### PR TITLE
simplifying how we reduce Boudewyn Tables

### DIFF
--- a/CBM_vol2biomass.R
+++ b/CBM_vol2biomass.R
@@ -343,6 +343,7 @@ Init <- function(sim) {
       canfi_code     = CanfiCode,
       name           = tolower(EN_generic_full),
       forest_type_id = sapply(Broadleaf, ifelse, "1", "3"),
+      is_sw = Broadleaf,
       NFI
     )] |>
       tidyr::extract(NFI, into = c("genus", "species"), "(.*)_([^_]+)$") |>

--- a/CBM_vol2biomass.R
+++ b/CBM_vol2biomass.R
@@ -221,12 +221,16 @@ Init <- function(sim) {
   ## productivity).
 
   userGcM3 <- sim$userGcM3
-    #}
+
+  # START reducing Biomass model parameter tables --------------------------------------------
   spu <- unique(sim$spatialDT$spatial_unit_id)
   eco <- unique(sim$spatialDT$ecozones)
 
   thisAdmin <- sim$cbmAdmin[sim$cbmAdmin$SpatialUnitID %in% spu & sim$cbmAdmin$EcoBoundaryID %in% eco, ]
 
+  # subsetting Boudewyn tables to the ecozones/admin boundaries of the study area.
+  # Some ecozones/boundaries are not in these tables, in these cases, the function replaces them in
+  # thisAdmin to the closest equivalent present in the Boudewyn tables.
   stable3 <- boudewynSubsetTables(sim$table3, thisAdmin, eco)
   stable4 <- boudewynSubsetTables(sim$table4, thisAdmin, eco)
   stable5 <- boudewynSubsetTables(sim$table5, thisAdmin, eco)

--- a/CBM_vol2biomass.R
+++ b/CBM_vol2biomass.R
@@ -227,99 +227,11 @@ Init <- function(sim) {
 
   thisAdmin <- sim$cbmAdmin[sim$cbmAdmin$SpatialUnitID %in% spu & sim$cbmAdmin$EcoBoundaryID %in% eco, ]
 
-
-  # START reducing Biomass model parameter tables -----------------------------------------------
-  # not all ecozones are in tables 3-7. There may be some mismatch here.
-  # these are the ecozones in the tables
-  # id               name
-  # 4       Taiga Plains
-  # 5  Taiga Shield West
-  # 6 Boreal Shield West
-  # 7  Atlantic Maritime
-  # 9      Boreal Plains
-  # 10  Subhumid Prairies
-  # 12  Boreal Cordillera
-  # 13   Pacific Maritime
-  # 14 Montane Cordillera
-  # these are the ones that are not.
-  # id               name
-  # 8   Mixedwood Plains  - 7  Atlantic Maritime
-  # 11   Taiga Cordillera - 4 taiga plains
-  # 15      Hudson Plains - 6 Boreal Shield West
-  # 16  Taiga Shield East - 5  Taiga Shield West
-  # 17 Boreal Shield East - 6 Boreal Shield West
-  # 18  Semiarid Prairies - 10  Subhumid Prairies
-
-  ecoNotInT <- c(8, 11, 15, 16, 17, 18)
-  if (any(eco %in% ecoNotInT)) {
-    EcoBoundaryID <- c(7, 4, 6, 5, 6, 10)
-    ecoReplace <- data.table(ecoNotInT, EcoBoundaryID)
-    thisAdmin <- merge(ecoReplace, thisAdmin, by.x = "ecoNotInT", by.y = "EcoBoundaryID")
-  }
-
-  if (any(eco %in% ecoNotInT)) {
-    stable3 <- as.data.table(sim$table3[sim$table3$juris_id %in% thisAdmin$abreviation &
-                                          sim$table3$ecozone %in% thisAdmin$EcoBoundaryID, ])
-    stable4 <- as.data.table(sim$table4[sim$table4$juris_id %in% thisAdmin$abreviation &
-                                          sim$table4$ecozone %in% thisAdmin$EcoBoundaryID, ])
-  } else {
-    stable3 <- as.data.table(sim$table3[sim$table3$juris_id %in% thisAdmin$abreviation &
-                                          sim$table3$ecozone %in% eco, ])
-    stable4 <- as.data.table(sim$table4[sim$table4$juris_id %in% thisAdmin$abreviation &
-                                          sim$table4$ecozone %in% eco, ])
-  }
-
-  abreviation <- c("PE", "QC", "ON", "MB", "SK", "YK", "NU", "NS")
-  ## DANGER HARD CODED: if NFIS changes table 5, this will no longer be valid
-  # juris_id: there are only 5/13 possible
-  # these are the provinces available: AB BC NB NF NT
-  # for the non match these would be the equivalent
-  # "PE" - NB
-  # "QC" - NB
-  # "ON" - NB
-  # "MB" - AB
-  # "SK" - AB
-  # "YK" - NT
-  # "NU" - NT
-  # "NS" - NB
-  if (any(thisAdmin$abreviation %in% abreviation)) {
-    t5abreviation <- c("NB", "NL", "NL", "AB", "AB", "NT", "NT", "NB")
-    abreviationReplace <- data.table(abreviation, t5abreviation)
-    # replace the abbreviations and select
-    thisAdmin5 <- merge(abreviationReplace, thisAdmin)
-    thisAdmin5[, c("abreviation", "t5abreviation") := list(t5abreviation, NULL)]
-    stable5.2 <- as.data.table(sim$table5[sim$table5$juris_id %in% thisAdmin5$abreviation, ])
-    stable5 <- stable5.2[ecozone %in% thisAdmin$EcoBoundaryID, ]
-  } else {
-    stable5.2 <- as.data.table(sim$table5[sim$table5$juris_id %in% thisAdmin$abreviation, ])
-    stable5 <- stable5.2[ecozone %in% thisAdmin$EcoBoundaryID, ]
-  }
-  # This second "if-statement" is to catch is the "no-ecozone" match
-  ### THIS NEEDS TO BE TESTED
-  if (nrow(stable5.2) > 0) {
-    stable5 <- stable5.2[ecozone %in% thisAdmin$EcoBoundaryID, ]
-  } else {
-    stop(
-      "There are no matches found for the parameters needed to execute the Boudewyn models.",
-      "Please manually find matches for table 5."
-    )
-  }
-
-  if (nrow(stable5) < 1) {
-    stop("There is a problem finding a parameter match in table 5.")
-  }
-
-  if (any(eco %in% ecoNotInT)) {
-    stable6 <- as.data.table(sim$table6[sim$table6$juris_id %in% thisAdmin$abreviation &
-                                          sim$table6$ecozone %in% thisAdmin$EcoBoundaryID, ])
-    stable7 <- as.data.table(sim$table7[sim$table7$juris_id %in% thisAdmin$abreviation &
-                                          sim$table7$ecozone %in% thisAdmin$EcoBoundaryID, ])
-  } else {
-    stable6 <- as.data.table(sim$table6[sim$table6$juris_id %in% thisAdmin$abreviation &
-                                          sim$table6$ecozone %in% eco, ])
-    stable7 <- as.data.table(sim$table7[sim$table7$juris_id %in% thisAdmin$abreviation &
-                                          sim$table7$ecozone %in% eco, ])
-  }
+  stable3 <- boudewynSubsetTables(sim$table3, thisAdmin, eco)
+  stable4 <- boudewynSubsetTables(sim$table4, thisAdmin, eco)
+  stable5 <- boudewynSubsetTables(sim$table5, thisAdmin, eco)
+  stable6 <- boudewynSubsetTables(sim$table6, thisAdmin, eco)
+  stable7 <- boudewynSubsetTables(sim$table7, thisAdmin, eco)
 
   # END reducing Biomass model parameter tables -----------------------------------------------
 
@@ -541,7 +453,6 @@ Init <- function(sim) {
 
   increments[is.na(increments), ] <- 0
   sim$growth_increments <- increments
-
 
   # END process growth curves -------------------------------------------------------------------------------
   # ! ----- STOP EDITING ----- ! #


### PR DESCRIPTION
This PR changes the way we subset the Boudewyn tables to the ecozones and administrative boundaries of the study area. Instead of directly in the module code, this step is now done by the boudewynSubsetTables function in CBMutils.