### PR TITLE
Module clean-up

### DIFF
--- a/tests/testthat/test-1-module_1-defaults.R
+++ b/tests/testthat/test-1-module_1-defaults.R
@@ -23,10 +23,9 @@ test_that("Module runs with defaults", {
       outputPath  = file.path(projectPath, "outputs")
     ),
 
-    spatialDT = data.frame(
+    userGcSPU = data.frame(
       spatial_unit_id = 28,
-      ecozones        = 9,
-      gcids           = 1
+      gcID            = 1
     )
   )
 
@@ -41,21 +40,34 @@ test_that("Module runs with defaults", {
   expect_s4_class(simTest, "simList")
 
 
-  ## Check output 'volCurves' ----
+  ## Check outputs 'volCurves' ----
 
   expect_true(!is.null(simTest$volCurves))
   expect_true(inherits(simTest$volCurves, "ggplot"))
+
 
   ## Check output 'cumPoolsClean' ----
 
   expect_true(!is.null(simTest$cPoolsClean))
   expect_true(inherits(simTest$cPoolsClean, "data.table"))
 
+  expect_true("28_1" %in% simTest$cPoolsClean$gcids)
+
+
+  ## Check output 'gcMeta' ---
+
+  expect_true(!is.null(simTest$gcMeta))
+  expect_true(inherits(simTest$gcMeta, "data.table"))
+
+  expect_true("28_1" %in% simTest$gcMeta$gcids)
+
 
   ## Check output 'growth_increments' ----
 
   expect_true(!is.null(simTest$growth_increments))
   expect_true(inherits(simTest$growth_increments, "data.table"))
+
+  expect_true("28_1" %in% simTest$growth_increments$gcids)
 
 })
 


### PR DESCRIPTION
In preparation of another upcoming PR regarding the new CBM_dataPrep module: here's a bit of clean up I did while I was in the module. The functionality of the module is the same.

Module metadata updates:
- Depreciated 'spatialUnits' and 'ecozones' inputs removed from input list
- Inputs reordered to have the Boundewyn tables at the bottom of the list

.inputObjects and Init updates:
- Object read in order updated to read all the Boundewyn tables last
- Table column assertions moved from .inputObjects to the top of Init
- Added temporary assertion: `curveID` must be "gcids" (since "gcids" is hardcoded through a lot of the event)
- `"gcids"` replaced with `sim$curveID` in 2 places: the yearly volume conversion & the curve plotting (to start the process of allowing other curveID)
- TODO comment removed to translate volumes to yearly volumes if not already (since this is done in `Init`)