### PR TITLE
curveID update

### DIFF
--- a/tests/testthat/test-1-module_1-defaults.R
+++ b/tests/testthat/test-1-module_1-defaults.R
@@ -23,10 +23,9 @@ test_that("Module runs with defaults", {
       outputPath  = file.path(projectPath, "outputs")
     ),
 
-    spatialDT = data.frame(
+    userGcSPU = data.frame(
       spatial_unit_id = 28,
-      ecozones        = 9,
-      gcids           = 1
+      gcID            = 1
     )
   )
 
@@ -41,21 +40,34 @@ test_that("Module runs with defaults", {
   expect_s4_class(simTest, "simList")
 
 
-  ## Check output 'volCurves' ----
+  ## Check outputs 'volCurves' ----
 
   expect_true(!is.null(simTest$volCurves))
   expect_true(inherits(simTest$volCurves, "ggplot"))
+
 
   ## Check output 'cumPoolsClean' ----
 
   expect_true(!is.null(simTest$cPoolsClean))
   expect_true(inherits(simTest$cPoolsClean, "data.table"))
 
+  expect_true("28_1" %in% simTest$cPoolsClean$gcids)
+
+
+  ## Check output 'gcMeta' ---
+
+  expect_true(!is.null(simTest$gcMeta))
+  expect_true(inherits(simTest$gcMeta, "data.table"))
+
+  expect_true("28_1" %in% simTest$gcMeta$gcids)
+
 
   ## Check output 'growth_increments' ----
 
   expect_true(!is.null(simTest$growth_increments))
   expect_true(inherits(simTest$growth_increments, "data.table"))
+
+  expect_true("28_1" %in% simTest$growth_increments$gcids)
 
 })
 


### PR DESCRIPTION
This is the follow up to the discussion about unique growth curves in [CBM_dataPrep issue 1](https://github.com/PredictiveEcology/CBM_dataPrep/pull/1). I started as exploration of how things work (and why they are failing) but it's now a working brainstorm of one way to solve the issue we are having. @camillegiuliano I'm interested in if you think this approach could be helpful in the RIA.

I'm looking for a solution to this now because I'm having issues getting `CBM_dataPrep` to work in SK. I'm finding that making a small change to how resampling to the masterRaster is done has caused mismatch issues between the `gcIndexLocator` raster and `ecoLocator` shapefile along the edges of the ecozones. While it's maybe a small issue that could be sidestepped, I'm realizing this would likely continue to be an issue if we tried running SK in higher or lower resolutions.

_The issue_: in SK, because the growth curve IDs have been pre-prepared to be unique to every ecozone in for CBM_vol2biomass, it's possible in the resampling process to get invalid (more than one) combos of "gcids" and "ecozone" along the ecozone edge, despite the fact that the actual volume curves are identical across the ecozone boundary. I hope that makes sense - It's a bit hard to describe in words unfortunately.

We are also encountering a similar issue in RIA: we have been trying to add "ecozone" to `sim$curveID` to get unique growth increments but that isn't enough: we have areas in one ecozone in both SK and AB (TBD: if this is right). Regardless, it is clear that we'll have to assert that each unique growth curve belongs to a single ecozone AND jurisdiction (or spatial_unit_id), otherwise `cumPoolsCreate` will fail.

_The proposed solution_: For SK, merge the duplicate growth curves. Expect just one initial "gc ID" for each unique initial volume curve regardless of where it is. This will make the SK data prep more like other study areas (like RIA) we want to introduce, allowing us to settle on a more standard way of preparing the increments. This takes away the risk of having resampling alignment issues.

_How it works_: Make `CBM_vol2biomass` (and related modules like `CBM_vol2biomas_RIA`) responsible for creating a new unique "gcid" for every `growth curve * ecozone * jurisdiction` or `growth curve * spatial_unit_id`.

**Object changes:**
- `spatialDT` renamed `userGcSPU`: This table requires the columns `sim$curveID` (which can be anything) and `spatial_unit_id`. This contains all the combos of `curveID` and `spatial_unit_id` that we'll need new growth increments for.
- New input object `userGcMeta` replaces `gcMeta`, and `gcMeta` is now instead an output object: this distinguishes the metadata about the input volumes (`userGcM3`) from the output metadata about the growth increments (`growth_increments`) since those are tied to spatial units.

We could also choose to use "ecozone" and "jurisID" instead of "spatial_unit_id" to distinguish each unique output curve. It wouldn't look much different.

**Changes in the `Init` event:**
- The "gcids" unique column is created
- The section where the SK white birch volumes are altered is updated to reference the the new "gcids" that include the spatial_unit_id
- Assertions updated to check the new input object formats

Otherwise: I could move this work back into `CBM_dataPrep` (where I first drafted it) and we can add assertions to our `CBM_vol2biomass` modules that the curves are unique to each `spatial_unit_id`. If we go that route, it is maybe a good idea to have an assertion in `CBM_dataPrep` that `curveID` always includes `spatial_unit_id`. However, this puts more work on the user.