### PR TITLE
Removing study area-specific fixes

### DIFF
--- a/CBM_vol2biomass_SK.R
+++ b/CBM_vol2biomass_SK.R
@@ -392,46 +392,6 @@ Init <- function(sim) {
     sim$curveID <- "curveID"
   }
 
-  if (!suppliedElsewhere("userGcMeta", sim)) {
-    if (!suppliedElsewhere("userGcMetaURL", sim)) {
-      sim$userGcMetaURL <- extractURL("userGcMeta")
-    }
-
-    sim$userGcMeta <- prepInputs(url = sim$userGcMetaURL,
-                                 targetFile = "gcMetaEg.csv",
-                                 destinationPath = inputPath(sim),
-                                 fun = fread,
-                                 purge = 7
-    )
-    data.table::setnames(sim$userGcMeta, "gcids", "curveID")
-    data.table::setkey(sim$userGcMeta, curveID)
-
-    sim$userGcMeta[, sw_hw := data.table::fifelse(forest_type_id == 1, "sw", "hw")]
-  }
-
-  if (!suppliedElsewhere("userGcM3", sim)){
-
-    if (suppliedElsewhere("userGcM3URL", sim)){
-
-      sim$userGcM3 <- prepInputs(url = sim$userGcM3URL,
-                                 destinationPath = inputPath(sim),
-                                 fun = "data.table::fread")
-
-    }else{
-
-      message("User has not supplied growth curves ('userGcM3' or 'userGcM3URL'). ",
-              "Defaults for Saskatchewan will be used.")
-
-      sim$userGcM3 <- prepInputs(url = extractURL("userGcM3"),
-                                 destinationPath = inputPath(sim),
-                                 targetFile = "userGcM3.csv",
-                                 fun = "data.table::fread")
-      data.table::setnames(sim$userGcM3, names(sim$userGcM3), c("curveID", "Age", "MerchVolume"))
-      data.table::setkeyv(sim$userGcM3, c("curveID", "Age"))
-
-    }
-  }
-
   # cbmAdmin: this is needed to match species and parameters. Boudewyn et al 2007
   # abbreviation and cbm spatial units and ecoBoudnary id is provided with the
   # adminName to avoid confusion.


### PR DESCRIPTION
This PR removes old birch-related fixes from the module as these are outdated and current curve fixes will now occur in `CBM_dataPrep_SK` (in this PR: https://github.com/PredictiveEcology/CBM_dataPrep_SK/pull/69). 
This PR also removes old links to default tables that are no longer used.  

With this change, this version of `CBM_vol2biomass_SK` is now a generic module with no study-area specific code and we could consider dropping the `_SK` portion of its name. 

Note: this will fail tests due to the Google authorization issue with this module when PRing from a different repository