### PR TITLE
sppMatchTable gets genus from CBMutils::sppMatch instead of NFI column

### DIFF
--- a/CBM_vol2biomass_SK.R
+++ b/CBM_vol2biomass_SK.R
@@ -18,7 +18,7 @@ defineModule(sim, list(
   citation = list("citation.bib"),
   documentation = deparse(list("README.txt", "CBM_vol2biomass_SK.Rmd")),
   reqdPkgs = list(
-    "PredictiveEcology/CBMutils@development (>=2.3.2.9001)",
+    "PredictiveEcology/CBMutils@development (>=2.4.2.9000)",
     "ggforce", "ggplot2", "ggpubr", "mgcv", "quickPlot", "robustbase", "data.table", "patchwork"
   ),
   parameters = rbind(
@@ -184,12 +184,10 @@ ReadInputs <- function(sim) {
   if (any(!c("canfi_species", "sw_hw", "genus") %in% names(sim$userGcMeta))){
 
     sppMatchTable <- CBMutils::sppMatch(
-      sim$userGcMeta$species, return = c("CanfiCode", "Latin_full", "Broadleaf"))[, .(
+      sim$userGcMeta$species, return = c("CanfiCode", "Genus", "Broadleaf"))[, .(
         canfi_species = CanfiCode,
         sw_hw         = data.table::fifelse(Broadleaf, "hw", "sw"),
-        genus         = toupper(
-          sapply(strsplit(latinFull, ""), function(x) paste(x[1:4], collapse = ""))
-        )
+        genus         = Genus
       )]
 
     sim$userGcMeta <- cbind(


### PR DESCRIPTION
This PR matches the changes made here(https://github.com/PredictiveEcology/CBMutils/pull/73) and here(https://github.com/PredictiveEcology/CBM_dataPrep/pull/18)