### PR TITLE
Dealing with the shallow table warning

### DIFF
--- a/CBM_vol2biomass_SK.R
+++ b/CBM_vol2biomass_SK.R
@@ -336,7 +336,8 @@ Vol2Biomass <- function(sim){
 
   # 4. Calculating Increments
   incCols <- c("incMerch", "incFol", "incOther")
-  cPoolsClean <- copy(cPoolsClean) #HARDCODED FIX: making a copy of this table deals with the shallow table warning that happens in the line below. Warning likely originates from how the table is built in cumPoolsSmooth.
+  cPoolsClean <- copy(cPoolsClean) #TEMP FIX: making a copy of this table deals with the shallow table warning that happens in the line below.
+  ## This warning likely originates from how the table is dealt with in cumPoolsSmooth or cumPoolsCreate.
   cPoolsClean[, (incCols) := lapply(.SD, function(x) c(NA, diff(x))), .SDcols = colNames,
                 by = eval("gcids")]
   colsToUse33 <- c("age", "gcids", incCols)


### PR DESCRIPTION
We consistently get this lengthy warning in CBM_vol2biomass:
```
1:  In Cache(FUN = modCall(sim = sim, eventTime = cur[["eventTime"]],     eventType = cur[["eventType"]]), notOlderThan = notOlderThan,     .objects = moduleSpecificObjects, .functionName = paste0(moduleCall,         "::", cur[["eventType"]]), outputObjects = moduleSpecificOutputObjects,     cachePath = sim@paths[["cachePath"]], userTags = c(paste0("module:",         cur[["moduleName"]]), paste0("eventType:", cur[["eventType"]]),         paste0("eventTime:", time(sim))), classOptions = classOptions,     verbose = verbose, showSimilar = showSimilar):
2:    A shallow copy of this data.table was taken so that := can add or remove 3 columns by reference. At an earlier point, this data.table was copied by R (or was created manually using structure() or similar). Avoid names<- and attr<- which in R currently (and oddly) may copy the whole data.table. Use set* syntax instead to avoid copying: ?set, ?setnames and ?setattr. It's also not unusual for data.table-agnostic packages to produce tables affected by this issue. If this message doesn't help, please report your use case to the data.table issue tracker so the root cause can be fixed or this message improved.
```
From what I can tell this warning stems from how the table is dealt with in either the `cumPoolsCreate` or `cumPoolsSmooth` function but the warning itself is generated after this line when we add the increment columns to `cPoolsClean`. 
```
cPoolsClean[, (incCols) := lapply(.SD, function(x) c(NA, diff(x))), .SDcols = colNames,
                by = eval("gcids")]
```
The table still gets created as intended but the warning is consistent. If we create a copy of the table for this step we avoid the warning, which is what I did in this simple temporary fix here.
I don't think this is a permanent solution but it does remove the lengthy unhelpful warning for now. Comment in the code indicates this is a temporary solution.